### PR TITLE
pin babel/core version to 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/StackStorm/st2apidocgen",
   "devDependencies": {
-    "@babel/core": "^7.10.3",
+    "@babel/core": "7.0.0",
     "babel-eslint": "10.0.2",
     "eslint": "^6.0.1",
     "eslint-plugin-import": "^2.18.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "st2apidocgen",
   "description": "StackStorm API Documentation Generator",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "index.js",
   "bin": "./bin/cli.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/StackStorm/st2apidocgen",
   "devDependencies": {
-    "@babel/core": "7.4.5",
+    "@babel/core": "^7.10.3",
     "babel-eslint": "10.0.2",
     "eslint": "^6.0.1",
     "eslint-plugin-import": "^2.18.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "homepage": "https://github.com/StackStorm/st2apidocgen",
   "devDependencies": {
-    "@babel/core": "7.0.0",
     "babel-eslint": "10.0.2",
     "eslint": "^6.0.1",
     "eslint-plugin-import": "^2.18.0",
@@ -27,6 +26,7 @@
     "eslint-plugin-react": "^7.14.2"
   },
   "dependencies": {
+    "@babel/core": "7.0.0",
     "koa-logger": "3.2.0",
     "axios": "0.19.0",
     "@babel/plugin-proposal-class-properties": "7.4.0",


### PR DESCRIPTION
this should fix the following error 
```
#!/bin/bash -eo pipefail
if [[ "${ST2_BRANCH}" =~ ^v[0-9]+\.[0-9]+$ ]]; then
  st2apidocgen --render --output
elif [ "${ST2_BRANCH}" == "master" ]; then
  st2apidocgen --render --output
else
  st2apidocgen --render /${CIRCLE_BUILD_NUM} --output
fi

(node:195) UnhandledPromiseRejectionWarning: Error: Cannot find module '@babel/core'
 babelify@10 requires Babel 7.x (the package '@babel/core'). If you'd like to use Babel 6.x ('babel-core'), you should install 'babelify@8'.
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/st2apidocgen/node_modules/babelify/index.js:9:11)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
(node:195) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:195) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
which is described in https://github.com/StackStorm/st2apidocs/issues/9

fixes: https://github.com/StackStorm/st2apidocs/issues/9